### PR TITLE
require fully qualified image names

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@ Fetch the open source code related to Chainguard packages and images, as defined
 
 Fetch sources by image name and tag:
 ```
-$ chainguard-source --yes --image wolfi-base:latest
-$ chainguard-source -y -i python:latest
-$ chainguard-source -y -i jdk
+$ chainguard-source --yes --image cgr.dev/chainguard/wolfi-base:latest
+$ chainguard-source -y -i cgr.dev/chainguard/python:latest
+$ chainguard-source -y -i cgr.dev/chainguard/jdk
 ```
 
 Fetch sources by package name and version:

--- a/chainguard-source
+++ b/chainguard-source
@@ -56,7 +56,7 @@ info() {
 
 # Check dependencies
 checkdeps() {
-	for i in bunzip2 cosign jq git gzip sha512sum tar wget xz; do
+	for i in bunzip2 cosign jq git gzip sha512sum ssh tar wget xz; do
 		type $i 2>&1 >/dev/null || error "Please install [$i]."
 	done
 }

--- a/chainguard-source
+++ b/chainguard-source
@@ -9,7 +9,6 @@ $0 [OPTIONS] [ -i|--image IMAGE[:TAG] | -p|--package PACKAGE | -s|--sbom SBOM.sp
 
 Options:
  -i|--image IMAGE[:TAG]		target image to fetch sources
-				if unspecified, will prepend cgr.dev/chainguard/IMAGE[:TAG]
  -p|--package PACKAGE		target wolfi package to fetch sources
  -s|--sbom SBOM.spdx.json	target sbom to process, fetching all referenced sources
  -a|--arch [amd64|arm64]	Default = amd64
@@ -18,11 +17,7 @@ Options:
  				warning prompt that this tool will use a lot of
 				network and disk
 
-IMAGE:		Image short name, as in the * in: cgr.dev/chainguard/*
-		  - wolfi-base:latest
-		  - python:3.11
-		  - openjdk
-		Or, fully qualified, as in: cgr.dev/foo/python-fips
+IMAGE:		Image name, as: cgr.dev/chainguard/python:latest
 		Default tag=:latest if unspecified
 
 PACKAGE:	Chainguard package short name, as in 'apk add FOO'
@@ -328,14 +323,7 @@ fi
 if [ ! -z "$IMAGE" ]; then
 	# Try to determine and retrieve sbom over network
 	# Make a directory to work in
-	case "$IMAGE" in
-		*/*)
-			image_url="$IMAGE"
-		;;
-		*)
-			image_url="cgr.dev/chainguard/$IMAGE"
-		;;
-	esac
+	image_url="$IMAGE"
 	WORK_DIR="$SOURCES_DIR/$image_url-$ARCH"
 	mkdir -p "$WORK_DIR"/sboms "$WORK_DIR"/artifacts
 	sbom="$WORK_DIR/sboms/$image_url-$ARCH.sbom.spdx.json"

--- a/chainguard-source
+++ b/chainguard-source
@@ -124,7 +124,8 @@ handle_ref() {
 		pkg:generic/*vcs_url=git+*)
 			# Strip the leading data
 			url=$(echo "$url" | sed -e "s/.*git+//")
-			git_checkout "$url"
+			local dest="$WORK_DIR"/$(echo "$ref" | sed -e "s:?:/:g")
+			git_checkout "$url" "$dest"
 		;;
 		pkg:generic/*download_url=*)
 			# Strip the leading data
@@ -185,6 +186,8 @@ handle_ref() {
 
 git_checkout() {
 	local ref="$1" repo= commit=
+	local dest="$2"
+	[ -z "$dest" ] && dest="$WORK_DIR/$ref"
 	case "$ref" in
 		pkg:github/*)
 			# Strip the leading data and extract the repo name (before the commit hash)
@@ -205,15 +208,15 @@ git_checkout() {
 	info "Cloning repo [$repo]"
 	[ "$DRYRUN" = "1" ] && return
 	# If we already have a clean git tree, then we can skip the clone (helps with re-runs)
-	if git -C "$WORK_DIR/$ref" status >/dev/null 2>&1 ; then
-		info "Already have a clean working repo [$repo] at [$WORK_DIR/$ref]"
+	if git -C "$dest" status >/dev/null 2>&1 ; then
+		info "Already have a clean working repo [$repo] at [$dest]"
 	else
 		# Directory is busted, or doesn't exist, so clone fresh from source
 		info "Need a clean working repo at [$repo]"
-		rm -rf "$WORK_DIR/$ref" && git clone "$repo" "$WORK_DIR/$ref"
+		rm -rf "$dest" && git clone "$repo" "$dest"
 	fi
 	# Rewind back to the exact specified commit in the SBOM
-	git -C "$WORK_DIR/$ref" checkout "$commit"
+	git -C "$dest" checkout "$commit"
 }
 
 package_to_sbom() {

--- a/chainguard-source
+++ b/chainguard-source
@@ -135,7 +135,11 @@ handle_ref() {
 			local checksum_method=$(echo "$checksum" | sed -e "s/:.*$//")
 			local checksum_hash=$(echo "$checksum" | sed -e "s/^.*://")
 			local cmd="$checksum_method""sum"
-			local target_filename="$WORK_DIR/artifacts/$(basename $url)"
+			local url_decoded=$(urldecode "$url")
+			local download_url_encoded=$(echo "$url" | sed -e "s/^.*&download_url=//")
+			local download_url=$(urldecode "$download_url_encoded")
+			local target_filename="$WORK_DIR"/$(echo "$ref" | sed -e "s/?.*$//")/"$download_url"
+			mkdir -p "$(dirname $target_filename)"
 			type "$cmd" 2>&1 >/dev/null || error "Please install [$cmd]"
 			info "Checking for local archive [$url]"
 			[ "$DRYRUN" = "1" ] && continue
@@ -151,12 +155,10 @@ handle_ref() {
 				(echo "$checksum_hash" | $cmd $target_filename 2>&1 >/dev/null) || error "Checksum [$checksum_hash] does not match for file [$target_filename]"
 			fi
 			info "Extracting archive [$target_filename]"
-			mkdir -p "$WORK_DIR/$ref"
-			tar xf "$target_filename" -C "$WORK_DIR/$ref"
+			tar xf "$target_filename" -C $(dirname "$target_filename")
 		;;
 		pkg:github/*)
-			# Strip the leading data
-			url=$(echo "$url" | sed -e "s|^pkg:github|https://github.com|")
+			info "Checking out [$url]"
 			git_checkout "$url"
 		;;
 		pkg:apk/wolfi*)
@@ -182,11 +184,21 @@ handle_ref() {
 }
 
 git_checkout() {
-	local url="$1"
-	# Extract the repo name (before the commit hash)
-	local repo=$(echo "$url" | sed -e "s/@.*$//")
+	local ref="$1" repo= commit=
+	case "$ref" in
+		pkg:github/*)
+			# Strip the leading data and extract the repo name (before the commit hash)
+			repo=$(echo "$ref" | sed -e "s|^pkg:github/||" -e "s/@.*$//")
+			# Fully qualify the git URL and use git over ssh for authentication to private repos
+			repo="git@github.com:$repo"
+		;;
+		*)
+			# Extract the repo name (before the commit hash)
+			repo=$(echo "$ref" | sed -e "s/@.*$//")
+		;;
+	esac
 	# Extract the commit hash
-	local commit=$(echo "$url" | sed -e "s/^.*@//" -e "s/#.*$//")
+	commit=$(echo "$ref" | sed -e "s/^.*@//" -e "s/#.*$//")
 	# Clone the whole repo (this can be a lot -- and you might get throttled)
 	# Use the fully qualified encoded URL as the directory name
 	# It's pretty darn long, but it should be guaranteed unique, and it's very informative...
@@ -314,6 +326,7 @@ if [ -f "$SBOM" ]; then
 	WORK_DIR="$SOURCES_DIR/$(basename $SBOM)"
 	mkdir -p "$WORK_DIR"/sboms "$WORK_DIR"/artifacts
 	sbom="$WORK_DIR/sboms/$(basename $SBOM)"
+	mkdir -p $(dirname "$sbom")
 	cat "$SBOM" > "$sbom"
 	info "Fetched sbom [$sbom]"
 	handle_sbom "$sbom"
@@ -323,15 +336,15 @@ fi
 if [ ! -z "$IMAGE" ]; then
 	# Try to determine and retrieve sbom over network
 	# Make a directory to work in
-	image_url="$IMAGE"
-	WORK_DIR="$SOURCES_DIR/$image_url"
-	mkdir -p "$WORK_DIR"/sboms "$WORK_DIR"/artifacts
-	sbom="$WORK_DIR/sboms/$image_url.sbom.spdx.json"
-	info "Fetching sbom [$ARCH] [$image_url]"
+	WORK_DIR="$SOURCES_DIR/$IMAGE"
+	mkdir -p "$WORK_DIR"/artifacts
+	sbom="$WORK_DIR/sboms/$IMAGE.sbom.spdx.json"
+	mkdir -p $(dirname "$sbom")
+	info "Fetching sbom [$ARCH] [$IMAGE]"
 	cosign download attestation \
 	  --platform linux/$ARCH \
 	  --predicate-type=https://spdx.dev/Document \
-	  $image_url | \
+	  $IMAGE | \
 	  jq '.payload | @base64d | fromjson | .predicate' > "$sbom"
 	info "Fetched sbom [$sbom]"
 	handle_sbom "$sbom"
@@ -340,12 +353,11 @@ fi
 # Handle target package
 if [ ! -z "$PACKAGE" ]; then
 	# Fetch package, extract sbom
-	package="$PACKAGE"
-	WORK_DIR="$SOURCES_DIR/$(basename $package)"
+	WORK_DIR="$SOURCES_DIR/$PACKAGE"
 	mkdir -p "$WORK_DIR"/sboms "$WORK_DIR"/artifacts
-	sbom="$WORK_DIR/sboms/$package.sbom.spdx.json"
-	info "Fetching sbom [$ARCH] [$package]"
-	package_to_sbom "$package" "$sbom"
+	sbom="$WORK_DIR/sboms/$PACKAGE.sbom.spdx.json"
+	info "Fetching sbom [$ARCH] [$PACKAGE]"
+	package_to_sbom "$PACKAGE" "$sbom"
 	info "Fetched sbom [$sbom]"
 	handle_sbom "$sbom"
 fi

--- a/chainguard-source
+++ b/chainguard-source
@@ -338,26 +338,26 @@ if [ ! -z "$IMAGE" ]; then
 	# Make a directory to work in
 	WORK_DIR="$SOURCES_DIR/$IMAGE"
 	mkdir -p "$WORK_DIR"/artifacts
-	sbom="$WORK_DIR/sboms/$IMAGE.sbom.spdx.json"
-	mkdir -p $(dirname "$sbom")
-	info "Fetching sbom [$ARCH] [$IMAGE]"
+	SBOM="$WORK_DIR/sboms/$IMAGE.sbom.spdx.json"
+	mkdir -p $(dirname "$SBOM")
+	info "Fetching SBOM [$ARCH] [$IMAGE]"
 	cosign download attestation \
 	  --platform linux/$ARCH \
 	  --predicate-type=https://spdx.dev/Document \
 	  $IMAGE | \
-	  jq '.payload | @base64d | fromjson | .predicate' > "$sbom"
-	info "Fetched sbom [$sbom]"
-	handle_sbom "$sbom"
+	  jq '.payload | @base64d | fromjson | .predicate' > "$SBOM"
+	info "Fetched SBOM [$SBOM]"
+	handle_sbom "$SBOM"
 fi
 
 # Handle target package
 if [ ! -z "$PACKAGE" ]; then
-	# Fetch package, extract sbom
+	# Fetch package, extract SBOM
 	WORK_DIR="$SOURCES_DIR/$PACKAGE"
 	mkdir -p "$WORK_DIR"/sboms "$WORK_DIR"/artifacts
-	sbom="$WORK_DIR/sboms/$PACKAGE.sbom.spdx.json"
-	info "Fetching sbom [$ARCH] [$PACKAGE]"
-	package_to_sbom "$PACKAGE" "$sbom"
-	info "Fetched sbom [$sbom]"
-	handle_sbom "$sbom"
+	SBOM="$WORK_DIR/sboms/$PACKAGE.sbom.spdx.json"
+	info "Fetching SBOM [$ARCH] [$PACKAGE]"
+	package_to_sbom "$PACKAGE" "$SBOM"
+	info "Fetched SBOM [$SBOM]"
+	handle_sbom "$SBOM"
 fi

--- a/chainguard-source
+++ b/chainguard-source
@@ -324,10 +324,10 @@ if [ ! -z "$IMAGE" ]; then
 	# Try to determine and retrieve sbom over network
 	# Make a directory to work in
 	image_url="$IMAGE"
-	WORK_DIR="$SOURCES_DIR/$image_url-$ARCH"
+	WORK_DIR="$SOURCES_DIR/$image_url"
 	mkdir -p "$WORK_DIR"/sboms "$WORK_DIR"/artifacts
-	sbom="$WORK_DIR/sboms/$image_url-$ARCH.sbom.spdx.json"
-	info "Fetching sbom [$ARCH/$image_url]"
+	sbom="$WORK_DIR/sboms/$image_url.sbom.spdx.json"
+	info "Fetching sbom [$ARCH] [$image_url]"
 	cosign download attestation \
 	  --platform linux/$ARCH \
 	  --predicate-type=https://spdx.dev/Document \
@@ -344,7 +344,7 @@ if [ ! -z "$PACKAGE" ]; then
 	WORK_DIR="$SOURCES_DIR/$(basename $package)"
 	mkdir -p "$WORK_DIR"/sboms "$WORK_DIR"/artifacts
 	sbom="$WORK_DIR/sboms/$package.sbom.spdx.json"
-	info "Fetching sbom [$ARCH/$package]"
+	info "Fetching sbom [$ARCH] [$package]"
 	package_to_sbom "$package" "$sbom"
 	info "Fetched sbom [$sbom]"
 	handle_sbom "$sbom"


### PR DESCRIPTION
**Dimitri John Ledkov**:  all tooling in containerd, crane, docker, chainctl expects full names. And simple name is always expected to be resolved against locally created or tagged image. Please do not do heuristics which are not what all other containers tools do when specifying image names