### PR TITLE
Do not fail on empty package block

### DIFF
--- a/chainguard-source
+++ b/chainguard-source
@@ -131,7 +131,7 @@ handle_sbom() {
 # Find all reference locator URLs in a target SBOM
 get_refs() {
 	local sbom="$1"
-	jq <"$sbom" -r '.packages[].externalRefs[].referenceLocator'
+	jq <"$sbom" -r '.packages[] | try .externalRefs[].referenceLocator'
 }
 
 # Decode URLs


### PR DESCRIPTION
Currently fails in the situation that any of the package blocks lack a .externalRefs element, even when there are other blocks to choose from.

Ultimately to fix
https://github.com/chainguard-dev/image-release-stats/issues/6378