### PR TITLE
fix: isolate arch in a purl query string

### DIFF
--- a/chainguard-source
+++ b/chainguard-source
@@ -280,7 +280,8 @@ package_to_sbom() {
 			# Looks like a purl, reformat to a usable URL
 			pkg_name=$(echo "$package" | sed -e "s:^.*/::" -e "s:@.*$::")
 			pkg_version=$(echo "$package" | sed -e "s:^.*@::" -e "s:?.*$::")
-			pkg_arch=$(echo "$package" | sed -e "s:^.*=::")
+			# get arch from purl that might look like: pkg:apk/wolfi/foo@bar?arch=x86_64&distro=wolfi
+			pkg_arch=$(echo "$package" | sed -e "s:^.*arch=::" -e "s:&.*$::")
 			url="https://packages.wolfi.dev/os/$pkg_arch/$pkg_name-$pkg_version.apk"
 		;;
 		*)


### PR DESCRIPTION
The `pkg_arch` matcher needs to handle package url query strings that contain more than 1 element:

```sh
PURL="pkg:apk/wolfi/ca-certificates-bundle@20250619-r5?arch=x86_64&distro=wolfi"

## Bad
echo ${PURL} | sed -e "s:^.*=::"
wolfi

## Good
echo ${PURL} | sed -e "s:^.*arch=::" -e "s:&.*$::"
x86_64
```